### PR TITLE
update gem dependencies

### DIFF
--- a/oplop.gemspec
+++ b/oplop.gemspec
@@ -14,10 +14,10 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "oplop"
 
-  s.add_dependency(%q<highline>, ["~> 1.6.1"])
-  s.add_development_dependency(%q<ruby-debug19>) 
-  s.add_development_dependency(%q<rspec>, ["~> 2.6.0"]) 
-  s.add_development_dependency(%q<yajl-ruby>, ["~> 0.8.2"])
+  s.add_dependency(%q<highline>, ["~> 1.6.20"])
+  s.add_development_dependency(%q<byebug>) 
+  s.add_development_dependency(%q<rspec>, ["~> 2.14.1"]) 
+  s.add_development_dependency(%q<yajl-ruby>, ["~> 1.2.0"])
   
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
some of the gems were incompatible when updating to ruby 2.0.0. Now oplop is working again for me.
